### PR TITLE
Add persona record management script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # rem-structure-records-
 "REM構文人格保存・進化記録用構文リポジトリ"
+
+## Example Usage
+
+```python
+from scripts.record_manager import save_persona, load_persona
+
+persona = {
+    "name": "REM",
+    "traits": ["curious", "helpful"]
+}
+
+save_persona(persona, "persona.json")
+loaded = load_persona("persona.json")
+print(loaded)
+```

--- a/scripts/record_manager.py
+++ b/scripts/record_manager.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def save_persona(persona: Dict[str, Any], file_path: str) -> None:
+    """Save persona data to a JSON file.
+
+    Parameters
+    ----------
+    persona : dict
+        Persona data to save.
+    file_path : str
+        Path to the JSON file where persona will be saved.
+    """
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open('w', encoding='utf-8') as f:
+        json.dump(persona, f, ensure_ascii=False, indent=2)
+
+
+def load_persona(file_path: str) -> Dict[str, Any]:
+    """Load persona data from a JSON file.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the JSON file to read.
+
+    Returns
+    -------
+    dict
+        Loaded persona data. If the file does not exist, an empty dict is
+        returned.
+    """
+    path = Path(file_path)
+    if not path.exists():
+        return {}
+    with path.open('r', encoding='utf-8') as f:
+        return json.load(f)


### PR DESCRIPTION
## Summary
- add `scripts/record_manager.py` for saving and loading persona JSON data
- document example usage of record manager in README

## Testing
- `python3 -m py_compile scripts/record_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_684018af63e0832099749d4267a010ae